### PR TITLE
chore(deps): widen pydantic constraint to <2.14.0 (supersedes #141)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,7 @@ classifiers = [
 dependencies = [
     # Core dependencies
     "mcp>=0.1.0",  # Model Context Protocol SDK - critical dependency
-    "pydantic>=2.6.0,<2.12.0",  # Compatible with safety tools
+    "pydantic>=2.6.0,<2.14.0",  # Compatible with safety tools
     "redis>=6.2.0",
     "PyYAML>=6.0",
     "chromadb>=0.4.0",


### PR DESCRIPTION
Widens the `pydantic` cap `<2.12.0` → `<2.14.0`, allowing 2.12/2.13.

Supersedes Dependabot **#141**, which has been failing CI — but its failures were **stale**: that PR's branch predates the build fixes in #160, so its CI still hit the old `project.version must be pep440` error. This PR is cut from current `main` (post-#160) for a clean verification.

Once this is green, #141 can be closed as superseded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)